### PR TITLE
feat: Add CORS configuration for frontend integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const http = require("http");
 const path = require("path");
 const { WebSocketServer } = require("ws");
 const dotenv = require("dotenv");
+const cors = require("cors");
 const sttRouter = require("./routes/stt");
 const sessionRouter = require("./routes/session");
 const monitoringRouter = require("./routes/monitoring");
@@ -14,6 +15,14 @@ dotenv.config();
 const app = express();
 const server = http.createServer(app);
 const wss = new WebSocketServer({ server });
+
+// CORS 설정 (프론트엔드 연동)
+app.use(cors({
+  origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization']
+}));
 
 app.use(express.json());
 app.use("/api/stt", sttRouter);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mediapipe/face_mesh": "^0.4.1633559619",
         "@ricky0123/vad-node": "^0.0.3",
         "compromise": "^14.14.4",
+        "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "formidable": "^3.5.4",
@@ -618,6 +619,19 @@
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/corser": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mediapipe/face_mesh": "^0.4.1633559619",
     "@ricky0123/vad-node": "^0.0.3",
     "compromise": "^14.14.4",
+    "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "formidable": "^3.5.4",


### PR DESCRIPTION
- Install and configure cors package
- Allow frontend origin (http://localhost:5173)
- Enable credentials and standard HTTP methods
- Add FRONTEND_URL and PORT to .env
- Support OPTIONS preflight requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)