### PR TITLE
fix: improve null/undefined safety in report APIs

### DIFF
--- a/services/analysis/MultimodalAnalyzer.js
+++ b/services/analysis/MultimodalAnalyzer.js
@@ -368,7 +368,7 @@ class MultimodalAnalyzer {
    * 인지 패턴 분류
    */
   _classifyCognitivePattern(cbtSummary) {
-    if (cbtSummary.totalDistortions === 0) return 'healthy';
+    if (!cbtSummary || cbtSummary.totalDistortions === 0) return 'healthy';
 
     const density = cbtSummary.totalDistortions / 10; // 10초 단위 기준
 
@@ -434,7 +434,7 @@ class MultimodalAnalyzer {
     }
 
     // 인지 패턴 기반
-    if (assessment.cognitivePattern.includes('distortion')) {
+    if (assessment.cognitivePattern && assessment.cognitivePattern.includes('distortion')) {
       recommendations.push({
         priority: 'high',
         category: 'cbt',


### PR DESCRIPTION
- Add safe defaults for session data in SessionReportGenerator
- Add null checks in MultimodalAnalyzer cognitive pattern analysis
- Improve error handling in summary() controller with try-catch
- Strengthen null/array validation before data iteration
- Prevent "Cannot convert undefined/null" errors on ended sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)