### PR TITLE
fix: increase grace period from 15s to 30s for Gemini emotion analysis

### DIFF
--- a/controllers/sessionController.js
+++ b/controllers/sessionController.js
@@ -89,11 +89,12 @@ async function end(req, res) {
     const session = SessionManager.endSession(sessionId);
 
     console.log(`⏹️ [CRITICAL] Session end requested: ${sessionId}`);
-    console.log(`⏳ [CRITICAL] Waiting 15 seconds for final Gemini responses to arrive...`);
+    console.log(`⏳ [CRITICAL] Waiting 30 seconds for final Gemini responses to arrive...`);
 
-    // ⏱️ Wait for final Gemini responses (8-13s latency) to be saved to database
+    // ⏱️ Wait for final Gemini responses (17-21s latency) to be saved to database
     // This grace period allows emotions analyzed after session ends to still be persisted
-    await new Promise(resolve => setTimeout(resolve, 15000));
+    // Increased from 15s to 30s to accommodate Gemini's typical latency
+    await new Promise(resolve => setTimeout(resolve, 30000));
 
     console.log(`✅ [CRITICAL] Grace period complete, fetching emotions from database...`);
 


### PR DESCRIPTION
Gemini API responses take 17-21 seconds to process, but the grace period was only 15 seconds. This caused WebSocket to close before Gemini responses arrived, preventing emotion updates from being sent to the frontend.

Changes:
- Increase grace period from 15000ms to 30000ms (30 seconds)
- Update logging to reflect new wait time
- Add comment explaining Gemini's actual latency

This ensures emotions analyzed after session ends are properly persisted to the database and displayed to the user.

🤖 Generated with Claude Code