### PR TITLE
fix: add database null check for emotion persistence

### DIFF
--- a/services/socket/landmarksHandler.js
+++ b/services/socket/landmarksHandler.js
@@ -183,6 +183,13 @@ function handleLandmarks(ws, session) {
           console.log(`💾 [CRITICAL] Attempting to save emotion to database...`);
 
           const db = require('../../models');
+
+          // DB가 비활성화되었으면 저장 생략
+          if (!db || !db.Session || !db.dbEnabled) {
+            console.warn(`⚠️  [CRITICAL] Database disabled or unavailable, skipping emotion save`);
+            return;
+          }
+
           const { Session } = db;
 
           // 1️⃣ 기존 세션 데이터 가져오기


### PR DESCRIPTION
- Added null check for db object before attempting Session.findOne()
- Gracefully handle case when database is disabled or unavailable
- Prevents 'Cannot read properties of null (reading findOne)' error
- Sessions table relationship no longer required for error-free operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)