### PR TITLE
fix(cors): add x-timestamp and x-client-version to allowed headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,8 +91,8 @@ app.use(cors({
   },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'x-request-id', 'x-device-id', 'x-csrf-token'],
-  exposedHeaders: ['x-request-id', 'x-device-id', 'x-csrf-token']
+  allowedHeaders: ['Content-Type', 'Authorization', 'x-request-id', 'x-device-id', 'x-csrf-token', 'x-timestamp', 'x-client-version'],
+  exposedHeaders: ['x-request-id', 'x-device-id', 'x-csrf-token', 'x-timestamp']
 }));
 // Preflight handled by CORS middleware (Express v5-safe)
 


### PR DESCRIPTION
Frontend sends x-timestamp and x-client-version headers but they were missing from CORS allowedHeaders.

This was causing preflight requests to fail with:
'Request header field x-timestamp is not allowed'

🤖 Generated with [Claude Code](https://claude.com/claude-code)