### PR TITLE
fix(db): manually parse DATABASE_URL to avoid IPv6 parsing issue

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -24,10 +24,16 @@ try {
   if (dbEnabled) {
     // DATABASE_URL이 있으면 config.json 없이도 작동
     if (process.env.DATABASE_URL) {
-      sequelize = new Sequelize(process.env.DATABASE_URL, {
+      // Sequelize의 URL 파싱 문제를 피하기 위해 직접 파싱
+      const dbUrl = new URL(process.env.DATABASE_URL);
+      sequelize = new Sequelize(dbUrl.pathname.slice(1), dbUrl.username, decodeURIComponent(dbUrl.password), {
+        host: dbUrl.hostname,
+        port: dbUrl.port || 5432,
         dialect: 'postgres',
-        protocol: 'postgres',
-        logging: false
+        logging: false,
+        dialectOptions: {
+          ssl: false
+        }
       });
     } else {
       // DATABASE_URL이 없으면 config.json 사용


### PR DESCRIPTION
Sequelize was mis-parsing DATABASE_URL with URL-encoded password, interpreting it as IPv6 address (2406:da12:...).

Solution:
- Parse URL manually using URL class
- Extract host, port, database, user, password separately
- Use decodeURIComponent for password to handle special chars

This fixes: connect ENETUNREACH IPv6 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)