### PR TITLE
fix(docs): resolve Mermaid diagram parsing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ graph TB
         WS[WebSocket Server<br/>ws library]
 
         subgraph "WebSocket 3 Channels"
-            WS1[/ws/landmarks<br/>Face Landmarks]
-            WS2[/ws/voice<br/>Audio Stream]
-            WS3[/ws/session<br/>Session Control]
+            WS1["Landmarks Channel<br/>(ws/landmarks)"]
+            WS2["Voice Channel<br/>(ws/voice)"]
+            WS3["Session Channel<br/>(ws/session)"]
         end
 
         subgraph "Core Services"


### PR DESCRIPTION
Fix lexical error in System Architecture diagram caused by forward slashes in node labels.

Issue:
  - Node labels starting with '/' caused Mermaid parser error
  - Error: 'Lexical error on line 11. Unrecognized text'

Solution:
  - Changed WebSocket channel node labels:
    * /ws/landmarks → Landmarks Channel (ws/landmarks)
    * /ws/voice → Voice Channel (ws/voice)
    * /ws/session → Session Channel (ws/session)
  - Used quoted labels to avoid parsing issues
  - Maintained information clarity with parenthetical paths

GitHub Mermaid now renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)